### PR TITLE
Adicionando module de Coordinator + testes unitários

### DIFF
--- a/libraries/core/Coordinator/Coordinator/Coordinator.swift
+++ b/libraries/core/Coordinator/Coordinator/Coordinator.swift
@@ -1,0 +1,33 @@
+import UIKit
+
+public protocol Coordinator: AnyObject {
+    
+    var parent: Coordinator? { get set }
+    var childCoordinators: [Coordinator] { get set }
+    var navigationController: UINavigationController { get set }
+    
+    init(navigationController: UINavigationController)
+    
+    func start()
+    func finish()
+}
+
+public extension Coordinator {
+    
+    static func instance(parent: Coordinator? = nil, navigationController: UINavigationController) -> Self {
+        let coordinator = Self.init(navigationController: navigationController)
+        coordinator.parent = parent
+        parent?.childCoordinators.append(coordinator)
+        return coordinator
+    }
+    
+    func finishCoordinator(_ child: Coordinator) {
+        guard let parent = parent else { return }
+        for (index, coordinator) in parent.childCoordinators.enumerated() {
+            if coordinator === child {
+                parent.childCoordinators.remove(at: index)
+                break
+            }
+        }
+    }
+}

--- a/libraries/core/Coordinator/Coordinator/Info.plist
+++ b/libraries/core/Coordinator/Coordinator/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/libraries/core/Coordinator/CoordinatorTests/CoordinatorMock.swift
+++ b/libraries/core/Coordinator/CoordinatorTests/CoordinatorMock.swift
@@ -1,0 +1,49 @@
+import UIKit
+@testable import Coordinator
+
+final class MockParentCoordinator: Coordinator {
+    var parent: Coordinator?
+    var childCoordinators: [Coordinator] = []
+    var navigationController: UINavigationController
+    
+    var data: String?
+    
+    required init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+    
+    func start(with data: String) {
+        self.data = data
+    }
+    
+    func start() { }
+    
+    func finish() { }
+    
+    func startChildCoordinator() {
+        let childCoordinator = MockChildCoordinator.instance(parent: self, navigationController: navigationController)
+        childCoordinator.start()
+    }
+    
+    func finishChildCoordinator() {
+        childCoordinators.first?.finish()
+    }
+}
+
+final class MockChildCoordinator: Coordinator {
+    var parent: Coordinator?
+    var childCoordinators: [Coordinator] = []
+    var navigationController: UINavigationController
+    
+    required init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+    
+    func setup(with data: Any?) { }
+    
+    func start() { }
+    
+    func finish() {
+        finishCoordinator(self)
+    }
+}

--- a/libraries/core/Coordinator/CoordinatorTests/CoordinatorTests.swift
+++ b/libraries/core/Coordinator/CoordinatorTests/CoordinatorTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+@testable import Coordinator
+
+final class CoordinatorTests: XCTestCase {
+    private var flowData: String = "FLOWDATA"
+    
+    func testNewInstances() {
+        let sut = makeSUT()
+        
+        sut.startChildCoordinator()
+        sut.startChildCoordinator()
+        
+        XCTAssertEqual(sut.childCoordinators.count, 2)
+        XCTAssertTrue(sut.childCoordinators.first is MockChildCoordinator)
+    }
+    
+    func testFinishInstances() {
+        let sut = makeSUT()
+        
+        sut.startChildCoordinator()
+        sut.finishChildCoordinator()
+        
+        XCTAssertEqual(sut.childCoordinators.count, 0)
+    }
+    
+    func testFlowDataLoad() {
+        let sut = makeSUT()
+        
+        sut.start(with: flowData)
+        
+        XCTAssertEqual(sut.data, flowData)
+    }
+}
+
+private extension CoordinatorTests {
+    func makeSUT() -> MockParentCoordinator {
+        let navigationController = UINavigationController()
+        let parentCoordinator = MockParentCoordinator.instance(navigationController: navigationController)
+        return parentCoordinator
+    }
+}

--- a/libraries/core/Coordinator/CoordinatorTests/Info.plist
+++ b/libraries/core/Coordinator/CoordinatorTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/libraries/core/Coordinator/project.yml
+++ b/libraries/core/Coordinator/project.yml
@@ -1,0 +1,42 @@
+############
+# Targets
+############
+
+targets:
+
+  Coordinator:
+    
+    # templates
+    templates:
+      - StaticFramework
+    
+    # templateAttributes
+    templateAttributes:
+      frameworkPath: libraries/core/Coordinator
+    
+    dependencies:
+     - target: DependencyInjector
+      
+    # scheme
+    scheme:
+      gatherCoverageData: true
+      coverageTargets:
+        - Coordinator
+      testTargets:
+        - name: CoordinatorTests
+          parallelizable: true
+          randomExecutionOrder: true
+
+  CoordinatorTests:
+    
+    # templates
+    templates:
+      - FrameworkTests
+    
+    # templateAttributes
+    templateAttributes:
+      frameworkPath: libraries/core/Coordinator
+
+    # dependencies
+    dependencies:
+      - target: Coordinator

--- a/project.yml
+++ b/project.yml
@@ -13,3 +13,5 @@ include:
   relativePaths: false
 - path: libraries/domain/Authentication/project.yml
   relativePaths: false
+- path: libraries/core/Coordinator/project.yml
+  relativePaths: false


### PR DESCRIPTION
# Descrição

Esse Pull Request adiciona um novo module Core, chamado de `Coordinator`

```Swift
public protocol Coordinator: AnyObject {
    
    var parent: Coordinator? { get set }
    var childCoordinators: [Coordinator] { get set }
    var navigationController: UINavigationController { get set }
    
    init(navigationController: UINavigationController)
    
    func start()
    func finish()
}

public extension Coordinator {
    
    static func instance(parent: Coordinator? = nil, navigationController: UINavigationController) -> Self {
        let coordinator = Self.init(navigationController: navigationController)
        coordinator.parent = parent
        parent?.childCoordinators.append(coordinator)
        return coordinator
    }
    
    func finishCoordinator(_ child: Coordinator) {
        guard let parent = parent else { return }
        for (index, coordinator) in parent.childCoordinators.enumerated() {
            if coordinator === child {
                parent.childCoordinators.remove(at: index)
                break
            }
        }
    }
}

```